### PR TITLE
$feat(errors): add StepZenError hierarchy and handler

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
 import { cliService } from "../extension";
-import { formatError } from '../utils/errors';
 import { logger } from "../services/logger";
 import { UI } from "../utils/constants";
+import { handleError } from "../errors";
 
 /**
  * Deploys the current StepZen project to StepZen service
@@ -44,19 +44,7 @@ export async function deployStepZen() {
       
       logger.info("Deployment completed successfully");
     } catch (err) {
-      const message = formatError(err);
-      vscode.window.showErrorMessage(
-        `StepZen deployment failed: ${message}`,
-        { modal: false, detail: "Check the logs for more details." },
-        "View Logs"
-      ).then(selection => {
-        if (selection === "View Logs") {
-          // Show the StepZen output channel
-          logger.showOutput();
-        }
-      });
-      
-      logger.error(`Deploy failed: ${formatError(err, true)}`, err);
+      handleError(err);
     }
   });
 }

--- a/src/errors/CliError.ts
+++ b/src/errors/CliError.ts
@@ -1,0 +1,19 @@
+import { StepZenError } from './StepZenError';
+
+/**
+ * Error class for CLI-related errors
+ * Represents errors that occur when interacting with the StepZen CLI
+ */
+export class CliError extends StepZenError {
+  /**
+   * Creates a new CLI error
+   * 
+   * @param message The error message
+   * @param code A unique code representing the specific error
+   * @param cause The underlying cause of this error (optional)
+   */
+  constructor(message: string, code: string = 'CLI_ERROR', cause?: unknown) {
+    super(message, code, cause);
+    this.name = 'CliError';
+  }
+}

--- a/src/errors/NetworkError.ts
+++ b/src/errors/NetworkError.ts
@@ -1,0 +1,19 @@
+import { StepZenError } from './StepZenError';
+
+/**
+ * Error class for network-related errors
+ * Represents errors that occur during network operations like API calls
+ */
+export class NetworkError extends StepZenError {
+  /**
+   * Creates a new network error
+   * 
+   * @param message The error message
+   * @param code A unique code representing the specific error
+   * @param cause The underlying cause of this error (optional)
+   */
+  constructor(message: string, code: string = 'NETWORK_ERROR', cause?: unknown) {
+    super(message, code, cause);
+    this.name = 'NetworkError';
+  }
+}

--- a/src/errors/StepZenError.ts
+++ b/src/errors/StepZenError.ts
@@ -1,0 +1,39 @@
+/**
+ * Base error class for all StepZen-related errors
+ * Extends the standard Error class with additional context
+ */
+export class StepZenError extends Error {
+  /**
+   * A unique code representing the specific error
+   */
+  public code: string;
+
+  /**
+   * The original error that caused this error, if any
+   */
+  public cause?: unknown;
+
+  /**
+   * Creates a new StepZen error
+   * 
+   * @param message The error message
+   * @param code A unique code representing the specific error
+   * @param cause The underlying cause of this error (optional)
+   */
+  constructor(message: string, code: string, cause?: unknown) {
+    super(message);
+    this.name = 'StepZenError';
+    this.code = code;
+    this.cause = cause;
+    
+    // Capture stack trace correctly
+    Error.captureStackTrace(this, this.constructor);
+  }
+
+  /**
+   * Creates a string representation of the error
+   */
+  public toString(): string {
+    return `${this.name}[${this.code}]: ${this.message}`;
+  }
+}

--- a/src/errors/ValidationError.ts
+++ b/src/errors/ValidationError.ts
@@ -1,0 +1,19 @@
+import { StepZenError } from './StepZenError';
+
+/**
+ * Error class for validation-related errors
+ * Represents errors that occur when validating schemas, inputs, or configurations
+ */
+export class ValidationError extends StepZenError {
+  /**
+   * Creates a new validation error
+   * 
+   * @param message The error message
+   * @param code A unique code representing the specific error
+   * @param cause The underlying cause of this error (optional)
+   */
+  constructor(message: string, code: string = 'VALIDATION_ERROR', cause?: unknown) {
+    super(message, code, cause);
+    this.name = 'ValidationError';
+  }
+}

--- a/src/errors/handler.ts
+++ b/src/errors/handler.ts
@@ -1,0 +1,146 @@
+import * as vscode from 'vscode';
+import { StepZenError } from './StepZenError';
+import { CliError } from './CliError';
+import { ValidationError } from './ValidationError';
+import { NetworkError } from './NetworkError';
+import { logger } from '../services/logger';
+
+/**
+ * Central error handler for the StepZen extension
+ * Normalizes errors, logs them, and shows user-friendly notifications
+ * 
+ * @param error The error to handle (can be any type)
+ * @returns The normalized StepZenError
+ */
+export function handleError(error: unknown): StepZenError {
+  // Step 1: Normalize to StepZenError
+  const normalizedError = normalizeError(error);
+  
+  // Step 2: Log the full error with stack trace
+  logger.error(`${normalizedError.name}[${normalizedError.code}]: ${normalizedError.message}`, normalizedError);
+  
+  // Step 3: Show VS Code notification with friendly message
+  showErrorNotification(normalizedError);
+  
+  return normalizedError;
+}
+
+/**
+ * Normalize any error type to a StepZenError
+ * Wraps unknown errors in an appropriate StepZenError subclass
+ * 
+ * @param error The error to normalize (can be any type)
+ * @returns A normalized StepZenError
+ */
+function normalizeError(error: unknown): StepZenError {
+  // If already a StepZenError, return as is
+  if (error instanceof StepZenError) {
+    return error;
+  }
+  
+  // Handle standard Error objects
+  if (error instanceof Error) {
+    // Try to categorize based on error properties and message
+    if (error.message.includes('ENOTFOUND') || 
+        error.message.includes('ECONNREFUSED') ||
+        error.message.includes('fetch') ||
+        error.message.includes('network') ||
+        error.message.includes('HTTP')) {
+      return new NetworkError(
+        `Network request failed: ${error.message}`,
+        'NETWORK_REQUEST_FAILED',
+        error
+      );
+    }
+    
+    if (error.message.includes('validation') ||
+        error.message.includes('invalid') ||
+        error.message.includes('schema')) {
+      return new ValidationError(
+        `Validation failed: ${error.message}`,
+        'VALIDATION_FAILED',
+        error
+      );
+    }
+    
+    if (error.message.includes('command') ||
+        error.message.includes('process') ||
+        error.message.includes('spawn') ||
+        error.message.includes('CLI') ||
+        error.message.includes('exited with code')) {
+      return new CliError(
+        `CLI operation failed: ${error.message}`,
+        'CLI_OPERATION_FAILED',
+        error
+      );
+    }
+    
+    // Default to base StepZenError if no specific category is detected
+    return new StepZenError(
+      error.message,
+      'UNKNOWN_ERROR',
+      error
+    );
+  }
+  
+  // Handle string errors
+  if (typeof error === 'string') {
+    return new StepZenError(
+      error,
+      'STRING_ERROR',
+      new Error(error)
+    );
+  }
+  
+  // Handle other types (objects, etc.)
+  return new StepZenError(
+    `Unknown error: ${String(error)}`,
+    'UNKNOWN_ERROR_TYPE',
+    error
+  );
+}
+
+/**
+ * Show a user-friendly error notification with VS Code
+ * 
+ * @param error The StepZenError to show
+ */
+function showErrorNotification(error: StepZenError): void {
+  // Generate a user-friendly message based on error type
+  let friendlyMessage = getFriendlyErrorMessage(error);
+  
+  // Show notification with "Show Logs" action
+  vscode.window.showErrorMessage(
+    friendlyMessage,
+    { modal: false, detail: error.message },
+    'Show Logs'
+  ).then(selection => {
+    if (selection === 'Show Logs') {
+      logger.showOutput();
+    }
+  });
+}
+
+/**
+ * Get a user-friendly error message based on error type
+ * 
+ * @param error The StepZenError to get a friendly message for
+ * @returns A user-friendly error message
+ */
+function getFriendlyErrorMessage(error: StepZenError): string {
+  // Customize message based on error type
+  if (error instanceof CliError) {
+    return `StepZen CLI Error: ${error.message}`;
+  }
+  
+  if (error instanceof ValidationError) {
+    return `StepZen Validation Error: ${error.message}`;
+  }
+  
+  if (error instanceof NetworkError) {
+    return `StepZen Network Error: ${error.message}`;
+  }
+  
+  // Default message for base StepZenError
+  return `StepZen Error: ${error.message}`;
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Error module index
+ * Exports all StepZen error classes and utilities
+ */
+
+export * from './StepZenError';
+export * from './CliError';
+export * from './ValidationError';
+export * from './NetworkError';
+export * from './handler';

--- a/src/services/cli.ts
+++ b/src/services/cli.ts
@@ -3,19 +3,9 @@ import * as cp from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { formatError, createError, StepZenError } from '../utils/errors';
 import { logger } from './logger';
 import { resolveStepZenProjectRoot } from '../utils/stepzenProject';
-
-/**
- * Error class specifically for CLI operations
- */
-export class CliError extends StepZenError {
-  constructor(message: string, operation: string, cause?: unknown) {
-    super(message, operation, { cause, category: 'cli' });
-    this.name = 'CliError';
-  }
-}
+import { CliError } from '../errors';
 
 /**
  * Service for interacting with the StepZen CLI
@@ -58,10 +48,9 @@ export class StepzenCliService {
       
       const error = new CliError(
         errorMessage,
-        'StepZen Deploy',
+        'DEPLOY_FAILED',
         err
       );
-      logger.error(`Failed to deploy StepZen schema: ${formatError(error)}`, error);
       throw error;
     }
   }
@@ -160,10 +149,9 @@ export class StepzenCliService {
     } catch (err) {
       const error = new CliError(
         'Failed to execute StepZen request',
-        'StepZen Request',
+        'REQUEST_FAILED',
         err
       );
-      logger.error(`Failed to execute StepZen request: ${formatError(error)}`, error);
       throw error;
     }
   }
@@ -202,7 +190,7 @@ export class StepzenCliService {
       proc.on('error', (err) => {
         reject(new CliError(
           `Failed to spawn StepZen CLI: ${err.message}`,
-          `StepZen ${command}`,
+          'SPAWN_FAILED',
           err
         ));
       });
@@ -216,7 +204,7 @@ export class StepzenCliService {
             
           reject(new CliError(
             errorMsg,
-            `StepZen ${command}`,
+            'COMMAND_FAILED',
             stderr ? new Error(stderr) : undefined
           ));
         } else {
@@ -277,10 +265,9 @@ export class StepzenCliService {
       }
       
       proc.on('error', (err) => {
-        logger.error(`Failed to spawn StepZen CLI: ${err.message}`);
         reject(new CliError(
           `Failed to spawn StepZen CLI: ${err.message}`,
-          'StepZen CLI',
+          'SPAWN_FAILED',
           err
         ));
       });
@@ -292,10 +279,9 @@ export class StepzenCliService {
             ? `StepZen CLI exited with code ${code}: ${stderr.trim()}`
             : `StepZen CLI exited with code ${code}`;
             
-          logger.error(errorMsg);
           reject(new CliError(
             errorMsg,
-            'StepZen CLI',
+            'COMMAND_FAILED',
             stderr ? new Error(stderr) : undefined
           ));
         } else {

--- a/src/test/unit/errors/errors.test.ts
+++ b/src/test/unit/errors/errors.test.ts
@@ -1,0 +1,103 @@
+import * as assert from 'assert';
+import { StepZenError, CliError, ValidationError, NetworkError } from '../../../errors';
+
+suite('Error Classes Tests', () => {
+  suite('StepZenError', () => {
+    test('constructs with basic parameters', () => {
+      const error = new StepZenError('Error message', 'ERROR_CODE');
+      
+      assert.strictEqual(error.name, 'StepZenError');
+      assert.strictEqual(error.message, 'Error message');
+      assert.strictEqual(error.code, 'ERROR_CODE');
+      assert.strictEqual(error.cause, undefined);
+      assert.ok(error.stack, 'Should have a stack trace');
+    });
+
+    test('constructs with cause parameter', () => {
+      const cause = new Error('Original error');
+      const error = new StepZenError('Error message', 'ERROR_CODE', cause);
+      
+      assert.strictEqual(error.message, 'Error message');
+      assert.strictEqual(error.code, 'ERROR_CODE');
+      assert.strictEqual(error.cause, cause);
+    });
+
+    test('toString provides formatted message', () => {
+      const error = new StepZenError('Error message', 'ERROR_CODE');
+      
+      assert.strictEqual(error.toString(), 'StepZenError[ERROR_CODE]: Error message');
+    });
+  });
+
+  suite('CliError', () => {
+    test('constructs with message and code', () => {
+      const error = new CliError('CLI error', 'CLI_TEST_ERROR');
+      
+      assert.strictEqual(error.name, 'CliError');
+      assert.strictEqual(error.message, 'CLI error');
+      assert.strictEqual(error.code, 'CLI_TEST_ERROR');
+      assert.strictEqual(error.cause, undefined);
+    });
+
+    test('constructs with default code when not provided', () => {
+      const error = new CliError('CLI error');
+      
+      assert.strictEqual(error.code, 'CLI_ERROR');
+    });
+
+    test('constructs with cause parameter', () => {
+      const cause = new Error('Original error');
+      const error = new CliError('CLI error', 'CLI_TEST_ERROR', cause);
+      
+      assert.strictEqual(error.cause, cause);
+    });
+  });
+
+  suite('ValidationError', () => {
+    test('constructs with message and code', () => {
+      const error = new ValidationError('Validation error', 'VALIDATION_TEST_ERROR');
+      
+      assert.strictEqual(error.name, 'ValidationError');
+      assert.strictEqual(error.message, 'Validation error');
+      assert.strictEqual(error.code, 'VALIDATION_TEST_ERROR');
+      assert.strictEqual(error.cause, undefined);
+    });
+
+    test('constructs with default code when not provided', () => {
+      const error = new ValidationError('Validation error');
+      
+      assert.strictEqual(error.code, 'VALIDATION_ERROR');
+    });
+
+    test('constructs with cause parameter', () => {
+      const cause = new Error('Original error');
+      const error = new ValidationError('Validation error', 'VALIDATION_TEST_ERROR', cause);
+      
+      assert.strictEqual(error.cause, cause);
+    });
+  });
+
+  suite('NetworkError', () => {
+    test('constructs with message and code', () => {
+      const error = new NetworkError('Network error', 'NETWORK_TEST_ERROR');
+      
+      assert.strictEqual(error.name, 'NetworkError');
+      assert.strictEqual(error.message, 'Network error');
+      assert.strictEqual(error.code, 'NETWORK_TEST_ERROR');
+      assert.strictEqual(error.cause, undefined);
+    });
+
+    test('constructs with default code when not provided', () => {
+      const error = new NetworkError('Network error');
+      
+      assert.strictEqual(error.code, 'NETWORK_ERROR');
+    });
+
+    test('constructs with cause parameter', () => {
+      const cause = new Error('Original error');
+      const error = new NetworkError('Network error', 'NETWORK_TEST_ERROR', cause);
+      
+      assert.strictEqual(error.cause, cause);
+    });
+  });
+});

--- a/src/test/unit/errors/handler.test.ts
+++ b/src/test/unit/errors/handler.test.ts
@@ -1,0 +1,153 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { handleError, StepZenError, CliError, ValidationError, NetworkError } from '../../../errors';
+import { logger } from '../../../services/logger';
+
+// Mock the logger and vscode window
+let originalErrorFn: typeof logger.error;
+let originalShowOutputFn: typeof logger.showOutput;
+let originalShowErrorMessage: typeof vscode.window.showErrorMessage;
+let showErrorMessageCalls: Array<[string, any]> = [];
+let loggerErrorCalls: Array<[string, unknown]> = [];
+let loggerShowOutputCalled = false;
+
+suite('Error Handler Tests', () => {
+  setup(() => {
+    // Save original functions
+    originalErrorFn = logger.error;
+    originalShowOutputFn = logger.showOutput;
+    originalShowErrorMessage = vscode.window.showErrorMessage;
+    
+    // Reset tracking variables
+    showErrorMessageCalls = [];
+    loggerErrorCalls = [];
+    loggerShowOutputCalled = false;
+    
+    // Mock logger.error
+    logger.error = function(message: string, error?: unknown): void {
+      loggerErrorCalls.push([message, error]);
+    };
+    
+    // Mock logger.showOutput
+    logger.showOutput = function(): void {
+      loggerShowOutputCalled = true;
+    };
+    
+    // Mock vscode.window.showErrorMessage
+    vscode.window.showErrorMessage = function(message: string, options?: any, ...items: any[]): Thenable<any> {
+      showErrorMessageCalls.push([message, options]);
+      // If there are items and the first is "Show Logs", simulate clicking it
+      if (items && items.length > 0 && items[0] === 'Show Logs') {
+        return Promise.resolve('Show Logs');
+      }
+      return Promise.resolve(undefined);
+    };
+  });
+
+  teardown(() => {
+    // Restore original functions
+    logger.error = originalErrorFn;
+    logger.showOutput = originalShowOutputFn;
+    vscode.window.showErrorMessage = originalShowErrorMessage;
+  });
+
+  test('normalizes standard Error to StepZenError', () => {
+    // Arrange
+    const error = new Error('Standard error message');
+    
+    // Act
+    const result = handleError(error);
+    
+    // Assert
+    assert.strictEqual(result instanceof StepZenError, true);
+    assert.strictEqual(result.message, 'Standard error message');
+    assert.strictEqual(result.code, 'UNKNOWN_ERROR');
+    assert.strictEqual(result.cause, error);
+  });
+
+  test('preserves StepZenError subclasses', () => {
+    // Arrange
+    const cliError = new CliError('CLI error message', 'TEST_CLI_ERROR');
+    
+    // Act
+    const result = handleError(cliError);
+    
+    // Assert
+    assert.strictEqual(result, cliError, 'Should return the original error object');
+    assert.strictEqual(result.code, 'TEST_CLI_ERROR');
+  });
+
+  test('correctly identifies network errors', () => {
+    // Arrange
+    const networkError = new Error('ECONNREFUSED: Connection refused');
+    
+    // Act
+    const result = handleError(networkError);
+    
+    // Assert
+    assert.strictEqual(result instanceof NetworkError, true);
+    assert.strictEqual(result.code, 'NETWORK_REQUEST_FAILED');
+  });
+
+  test('correctly identifies validation errors', () => {
+    // Arrange
+    const validationError = new Error('Invalid schema: syntax error');
+    
+    // Act
+    const result = handleError(validationError);
+    
+    // Assert
+    assert.strictEqual(result instanceof ValidationError, true);
+    assert.strictEqual(result.code, 'VALIDATION_FAILED');
+  });
+
+  test('correctly identifies CLI errors', () => {
+    // Arrange
+    const cliError = new Error('Command exited with code 1');
+    
+    // Act
+    const result = handleError(cliError);
+    
+    // Assert
+    assert.strictEqual(result instanceof CliError, true);
+    assert.strictEqual(result.code, 'CLI_OPERATION_FAILED');
+  });
+
+  test('logs error with stack trace', () => {
+    // Arrange
+    const error = new Error('Test error message');
+    
+    // Act
+    handleError(error);
+    
+    // Assert
+    assert.strictEqual(loggerErrorCalls.length > 0, true);
+  });
+
+  test('shows notification with correct message', () => {
+    // Arrange
+    const error = new CliError('Test CLI error', 'TEST_ERROR');
+    
+    // Act
+    handleError(error);
+    
+    // Assert
+    assert.strictEqual(showErrorMessageCalls.length > 0, true);
+    // First call, first argument is the message
+    assert.strictEqual(showErrorMessageCalls[0][0], 'StepZen CLI Error: Test CLI error');
+  });
+
+  test('opens logs when Show Logs action is clicked', async () => {
+    // Arrange
+    const error = new Error('Test error message');
+    
+    // Act
+    handleError(error);
+    
+    // Need to use a timeout to allow the promise chain to complete
+    await new Promise(resolve => setTimeout(resolve, 10));
+    
+    // Assert - logger.showOutput should be called due to our mock
+    assert.strictEqual(loggerShowOutputCalled, true);
+  });
+});

--- a/src/test/unit/services/cli.test.ts
+++ b/src/test/unit/services/cli.test.ts
@@ -2,7 +2,8 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as os from 'os';
 import { createMock } from '../../../test/helpers/test-utils';
-import { StepzenCliService, CliError } from '../../../services/cli';
+import { StepzenCliService } from '../../../services/cli';
+import { CliError } from '../../../errors';
 import * as vscode from 'vscode';
 
 // This is a simplified test file that would be expanded in a real implementation


### PR DESCRIPTION
- Add StepZenError base class with 'code' property
- Add specialized subclasses: CliError, ValidationError, NetworkError
- Implement central handleError() to normalize errors, log them, and show notifications
- Update services and commands to use the new error system
- Add unit tests for error handling functionality

This change improves error reporting by providing more consistent and user-friendly
error messages, while also ensuring that errors are properly logged for debugging.
