### PR TITLE
$feat(architecture): implement dependency injection service registry

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,9 @@ suite("Your Test Suite Name", () => {
 
 All tests will be automatically compiled to the `out/test` directory and run by the VS Code test runner.
 
+For more detailed information about testing, including how to mock services in tests, please refer to the [test directory README](src/test/README.md).
+
+
 ## Feedback
 
 Feel free to open issues or suggest improvements!

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
-import { cliService } from "../extension";
-import { logger } from "../services/logger";
+import { services } from "../services";
 import { UI } from "../utils/constants";
 import { handleError } from "../errors";
 
@@ -15,11 +14,11 @@ export async function deployStepZen() {
   if (!vscode.workspace.isTrusted) {
     const message = "StepZen deployment is not available in untrusted workspaces. Open this folder in a trusted workspace to enable deployment.";
     vscode.window.showWarningMessage(message);
-    logger.warn(`Deploy failed: ${message}`);
+    services.logger.warn(`Deploy failed: ${message}`);
     return;
   }
 
-  logger.info("Starting deployment of StepZen project...");
+  services.logger.info("Starting deployment of StepZen project...");
 
   // Show deployment progress to the user
   return vscode.window.withProgress({
@@ -32,7 +31,7 @@ export async function deployStepZen() {
     try {
       // Use the CLI service to perform the deployment
       progress.report({ increment: 50, message: "Uploading schema to StepZen..." });
-      await cliService.deploy("");
+      await services.cli.deploy("");
       
       // Show success message to the user
       progress.report({ increment: 100, message: "Deployment completed!" });
@@ -42,7 +41,7 @@ export async function deployStepZen() {
         "OK"
       );
       
-      logger.info("Deployment completed successfully");
+      services.logger.info("Deployment completed successfully");
     } catch (err) {
       handleError(err);
     }

--- a/src/commands/goToDefinition.ts
+++ b/src/commands/goToDefinition.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { findDefinition } from "../utils/stepzenProjectScanner";
-import { logger } from "../services/logger";
+import { services } from "../services";
 
 /**
  * Implements Go to Definition functionality for GraphQL symbols
@@ -28,14 +28,14 @@ export async function goToDefinition() {
   const locations = findDefinition(token);
   if (!locations || locations.length === 0) {
     vscode.window.showWarningMessage(`No definition found for "${token}".`);
-    logger.warn(`No definition found for "${token}".`);
+    services.logger.warn(`No definition found for "${token}".`);
     return;
   }
 
   // Single location found - jump directly to it
   if (locations.length === 1) {
     const loc = locations[0];
-    logger.info(`Found "${token}" in ${loc.filePath}.`);
+    services.logger.info(`Found "${token}" in ${loc.filePath}.`);
     const uri = vscode.Uri.file(loc.filePath);
     const pos = new vscode.Position(loc.line, loc.character);
     const doc = await vscode.workspace.openTextDocument(uri);
@@ -47,7 +47,7 @@ export async function goToDefinition() {
 
   // Multiple locations found - offer a quick-pick list for user selection
   // Log message for debugging
-  logger.info(
+  services.logger.info(
     `Multiple definitions for "${token}" found. Prompting user to select one.`,
   );
   const pick = await vscode.window.showQuickPick(

--- a/src/commands/initializeProject.ts
+++ b/src/commands/initializeProject.ts
@@ -6,7 +6,7 @@ import { getOrCreateStepZenTerminal } from "../extension";
 import { resolveStepZenProjectRoot } from "../utils/stepzenProject";
 import { formatError, createError } from "../utils/errors";
 import { FILE_PATTERNS } from "../utils/constants";
-import { logger } from "../services/logger";
+import { services } from "../services";
 
 /**
  * Checks if the StepZen CLI is installed and properly configured
@@ -15,11 +15,11 @@ import { logger } from "../services/logger";
  */
 async function checkStepZenCLI(): Promise<boolean> {
   try {
-    logger.info("Checking StepZen CLI installation...");
+    services.logger.info("Checking StepZen CLI installation...");
 
     try {
       const version = execSync("stepzen --version").toString().trim();
-      logger.info(`Found StepZen CLI version: ${version}`);
+      services.logger.info(`Found StepZen CLI version: ${version}`);
     } catch (err) {
       const installOption = await vscode.window.showErrorMessage(
         "StepZen CLI is not installed. You need to install it to create a StepZen project.",
@@ -39,7 +39,7 @@ async function checkStepZenCLI(): Promise<boolean> {
     // Verify that user is logged in
     try {
       execSync("stepzen whoami");
-      logger.info("StepZen CLI is properly configured.");
+      services.logger.info("StepZen CLI is properly configured.");
     } catch (err) {
       const loginOption = await vscode.window.showErrorMessage(
         "You need to log in to StepZen before creating a project.",
@@ -59,7 +59,7 @@ async function checkStepZenCLI(): Promise<boolean> {
     return true;
   } catch (err) {
     vscode.window.showErrorMessage(`StepZen CLI error: ${formatError(err)}`);
-    logger.error(`StepZen CLI error: ${formatError(err, true)}`, err);
+    services.logger.error(`StepZen CLI error: ${formatError(err, true)}`, err);
     return false;
   }
 }
@@ -282,7 +282,7 @@ query HelloWorld {
 `;
     fs.writeFileSync(sampleOperationPath, sampleOperationContent);
 
-    logger.info(
+    services.logger.info(
       `Created StepZen project at: ${projectDir} with endpoint ${endpoint}`,
     );
   } catch (err) {
@@ -425,7 +425,7 @@ export async function initializeProject() {
 
     const endpoint = await promptForEndpoint();
     if (!endpoint) {
-      logger.info("Project initialization cancelled.");
+      services.logger.info("Project initialization cancelled.");
       return;
     }
 
@@ -468,7 +468,7 @@ export async function initializeProject() {
     vscode.window.showErrorMessage(
       `Failed to initialize StepZen project: ${error}`,
     );
-    logger.error(
+    services.logger.error(
       `Project initialization failed: ${formatError(err, true)}`,
       err
     );

--- a/src/commands/openExplorer.ts
+++ b/src/commands/openExplorer.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { execSync } from "child_process";
 import { formatError, createError } from "../utils/errors";
-import { logger } from "../services/logger";
+import { services } from "../services";
 import { StepZenConfig } from "../types";
 
 /**
@@ -89,7 +89,7 @@ export function openQueryExplorer(context: vscode.ExtensionContext) {
       "user"
     );
     vscode.window.showErrorMessage(formatError(error));
-    logger.error(formatError(error, true), error);
+    services.logger.error(formatError(error, true), error);
     return;
   }
   const workspaceFolderPath = workspaceFolders[0].uri.fsPath;
@@ -100,7 +100,7 @@ export function openQueryExplorer(context: vscode.ExtensionContext) {
   } catch (err) {
     const errorMsg = formatError(err);
     vscode.window.showErrorMessage(`Failed to get StepZen project info: ${errorMsg}`);
-    logger.error(formatError(err, true), err);
+    services.logger.error(formatError(err, true), err);
     return;
   }
 

--- a/src/commands/openSchemaVisualizer.ts
+++ b/src/commands/openSchemaVisualizer.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { openSchemaVisualizerPanel } from "../panels/schemaVisualizerPanel";
 import { EXTENSION_URI } from "../extension";
-import { logger } from "../services/logger";
+import { services } from "../services";
 
 /**
  * Opens the schema visualizer panel.
@@ -14,7 +14,7 @@ export async function openSchemaVisualizer(
   context: vscode.ExtensionContext,
   focusedType?: string,
 ) {
-  logger.info(
+  services.logger.info(
     `Opening Schema Visualizer command${focusedType ? ` focused on type: ${focusedType}` : ""}`,
   );
   

--- a/src/commands/runRequest.ts
+++ b/src/commands/runRequest.ts
@@ -9,11 +9,11 @@ import { parse, NamedTypeNode, OperationDefinitionNode } from "graphql";
 import { resolveStepZenProjectRoot } from "../utils/stepzenProject";
 import { formatError, createError } from "../utils/errors";
 import { clearResultsPanel, openResultsPanel } from "../panels/resultsPanel";
-import { logger } from "../services/logger";
 import { summariseDiagnostics, publishDiagnostics } from "../utils/runtimeDiagnostics";
-import { runtimeDiag, cliService } from "../extension";
+import { runtimeDiag } from "../extension";
 import { getOperationMap, getPersistedDocMap, OperationEntry } from "../utils/stepzenProjectScanner";
 import { UI, TIMEOUTS } from "../utils/constants";
+import { services } from "../services";
 import { StepZenConfig, StepZenResponse, StepZenDiagnostic } from "../types";
 // Import executeStepZenRequest from separate file
 import { executeStepZenRequest } from "./executeStepZenRequest";
@@ -28,8 +28,8 @@ import { handleError, ValidationError } from "../errors";
  * @returns Array of operation names found in the query
  */
 function extractOperationNames(query: string): string[] {
-  if (!query || typeof query !== 'string') {
-    logger.warn("Invalid query provided to extractOperationNames");
+  if (!query || typeof query !== "string") {
+    services.logger.warn("Invalid query provided to extractOperationNames");
     return [];
   }
   
@@ -59,7 +59,7 @@ function createTempGraphQLFile(query: string): string {
     `stepzen-request-${timestamp}.graphql`
   );
   fs.writeFileSync(tmp, query);
-  logger.debug(`Created temporary query file: ${tmp}`);
+  services.logger.debug(`Created temporary query file: ${tmp}`);
   return tmp;
 }
 
@@ -379,7 +379,7 @@ export async function runPersisted(documentId: string, operationName: string) {
 export function clearResults(): void {
   clearResultsPanel();
   runtimeDiag.clear(); // Also clear any diagnostics
-  logger.info("Results cleared");
+  services.logger.info("Results cleared");
 }
 
 /* -------------------------------------------------------------
@@ -449,14 +449,14 @@ function execAsync(command: string, options: cp.ExecOptions = {}): Promise<{ std
  */
 function cleanupLater(file: string, delayMs: number = TIMEOUTS.FILE_CLEANUP_DELAY_MS): void {
   // Add validation
-  if (!file || typeof file !== 'string') {
-    logger.warn("Invalid file path provided for cleanup");
+  if (!file || typeof file !== "string") {
+    services.logger.warn("Invalid file path provided for cleanup");
     return;
   }
 
   // Only attempt to clean up files in the temp directory
   if (!file.startsWith(os.tmpdir())) {
-    logger.warn(`Refusing to clean up non-temporary file: ${file}`);
+    services.logger.warn(`Refusing to clean up non-temporary file: ${file}`);
     return;
   }
 
@@ -464,7 +464,7 @@ function cleanupLater(file: string, delayMs: number = TIMEOUTS.FILE_CLEANUP_DELA
     try {
       if (fs.existsSync(file)) {
         fs.unlinkSync(file);
-        logger.debug(`Temporary file cleaned up: ${file}`);
+        services.logger.debug(`Temporary file cleaned up: ${file}`);
       }
     } catch (err) {
       handleError(new ValidationError(

--- a/src/panels/schemaVisualizerPanel.ts
+++ b/src/panels/schemaVisualizerPanel.ts
@@ -10,7 +10,7 @@ import {
   DirectiveInfo,
   TypeRelationship,
 } from "../utils/stepzenProjectScanner";
-import { logger } from "../services/logger";
+import { services } from "../services";
 import { resolveStepZenProjectRoot } from "../utils/stepzenProject";
 import * as path from "path";
 import * as fs from "fs";
@@ -39,7 +39,7 @@ export async function openSchemaVisualizerPanel(
   extensionUri: Uri,
   focusedType?: string,
 ) {
-  logger.info(
+  services.logger.info(
     `Opening Schema Visualizer${focusedType ? ` focused on type: ${focusedType}` : ""}`,
   );
 
@@ -76,7 +76,7 @@ export async function openSchemaVisualizerPanel(
           return;
         case "debug-log":
           // Log messages from the webview to the StepZen output channel
-          logger.debug(`[Webview] ${message.message}`);
+          services.logger.debug(`[Webview] ${message.message}`);
           return;
       }
     });
@@ -156,14 +156,14 @@ export async function openSchemaVisualizerPanel(
     const schemaModel = buildSchemaModel();
 
     // Debug logging
-    logger.debug(
+    services.logger.debug(
       `Schema model built: ${Object.keys(schemaModel.types).length} types, ${
         Object.keys(schemaModel.fields).length
       } fields with entries, ${schemaModel.relationships.length} relationships`,
     );
 
     if (Object.keys(schemaModel.types).length === 0) {
-      logger.warn("No types found in schema model");
+      services.logger.warn("No types found in schema model");
       panel.webview.html = getNoProjectHtml();
       return;
     }
@@ -177,7 +177,7 @@ export async function openSchemaVisualizerPanel(
     );
     
   } catch (error) {
-    logger.error(`Error loading schema visualizer`, error);
+    services.logger.error(`Error loading schema visualizer`, error);
     panel.webview.html = getNoProjectHtml();
   }
 }
@@ -203,11 +203,11 @@ async function ensureSchemaDataLoaded(): Promise<boolean> {
 
   // If we already have schema data, return true
   if (Object.keys(fieldIndex).length > 0) {
-    logger.debug("Using existing schema data");
+    services.logger.debug("Using existing schema data");
     return true;
   }
 
-  logger.info("Schema data not found, attempting to load project...");
+  services.logger.info("Schema data not found, attempting to load project...");
 
   try {
     // Find StepZen project root using the active editor or workspace folders
@@ -225,7 +225,7 @@ async function ensureSchemaDataLoaded(): Promise<boolean> {
 
     // If we have no hint, we can't proceed
     if (!hintUri) {
-      logger.warn("No workspace folder or active editor available");
+      services.logger.warn("No workspace folder or active editor available");
       return false;
     }
 
@@ -235,17 +235,17 @@ async function ensureSchemaDataLoaded(): Promise<boolean> {
 
     // Verify that the index file exists
     if (!fs.existsSync(indexPath)) {
-      logger.warn(`Index file not found at ${indexPath}`);
+      services.logger.warn(`Index file not found at ${indexPath}`);
       return false;
     }
 
     // Scan the project
-    logger.info(`Scanning StepZen project at ${indexPath}`);
+    services.logger.info(`Scanning StepZen project at ${indexPath}`);
     await scanStepZenProject(indexPath);
-    logger.debug("Schema scan completed successfully");
+    services.logger.debug("Schema scan completed successfully");
     return true;
   } catch (error) {
-    logger.error(`Failed to load schema data`, error);
+    services.logger.error(`Failed to load schema data`, error);
     return false;
   }
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,71 @@
+import { StepzenCliService } from './cli';
+import { Logger, logger } from './logger';
+
+/**
+ * Service registry for dependency injection of application services
+ * Acts as a lightweight container for singleton services
+ */
+export interface ServiceRegistry {
+  cli: StepzenCliService;
+  logger: Logger;
+}
+
+/**
+ * Default service implementations
+ */
+export const services: ServiceRegistry = {
+  cli: new StepzenCliService(),
+  logger,
+};
+
+/**
+ * Override services for testing
+ * 
+ * @param patch Partial service registry with mocked services
+ * @returns The previous services before override
+ */
+export function overrideServices(patch: Partial<ServiceRegistry>): Partial<ServiceRegistry> {
+  const previousServices: Partial<ServiceRegistry> = {};
+  
+  for (const [key, value] of Object.entries(patch)) {
+    const serviceKey = key as keyof ServiceRegistry;
+    // Store the original service before overriding
+    if (services[serviceKey]) {
+      previousServices[serviceKey] = services[serviceKey] as any;
+    }
+    // Apply the override
+    (services as any)[serviceKey] = value;
+  }
+  
+  return previousServices;
+}
+
+/**
+ * Reset overridden services with original implementations
+ * 
+ * @param previousServices Services to restore
+ */
+export function resetServices(previousServices: Partial<ServiceRegistry>): void {
+  for (const [key, value] of Object.entries(previousServices)) {
+    const serviceKey = key as keyof ServiceRegistry;
+    (services as any)[serviceKey] = value;
+  }
+}
+
+/**
+ * Set all services to mocks for testing
+ * Shorthand for replacing all services with mocks in tests
+ * 
+ * @param mocks Complete mocked service registry
+ * @returns The previous services before mocking
+ */
+export function setMockServices(mocks: ServiceRegistry): ServiceRegistry {
+  const previousServices = { ...services };
+  
+  for (const [key, value] of Object.entries(mocks)) {
+    const serviceKey = key as keyof ServiceRegistry;
+    (services as any)[serviceKey] = value;
+  }
+  
+  return previousServices;
+}

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -46,3 +46,59 @@ We aim for 100% statement, branch, and function coverage for all utility functio
 2. Use descriptive assertion messages to make test failures clear.
 3. Use the test helpers where appropriate to reduce boilerplate code.
 4. Consider edge cases and error conditions, not just the happy path.
+
+## Mocking Services in Tests
+
+The extension uses a dependency injection container for services (CLI, logger, etc.) that makes them easily mockable in tests:
+
+```typescript
+import { services, setMockServices, overrideServices } from "../../services";
+import { createMock } from "../helpers/test-utils";
+
+suite("Your Test Suite with Mocked Services", () => {
+  // Mock the entire service registry
+  test("Using complete service mocks", () => {
+    // Create mock services
+    const mockServices = {
+      cli: createMock({
+        deploy: async () => { /* mock implementation */ },
+        request: async () => "mock response"
+      }),
+      logger: createMock({
+        info: () => { /* mock implementation */ },
+        error: () => { /* mock implementation */ }
+      })
+    };
+    
+    // Replace all services with mocks
+    const origServices = setMockServices(mockServices);
+    
+    try {
+      // Your test code using services.cli and services.logger
+      // The mocked implementations will be used
+    } finally {
+      // Restore original services after the test
+      setMockServices(origServices);
+    }
+  });
+  
+  // Override specific services only
+  test("Using partial service overrides", () => {
+    // Create a partial override
+    const mockCli = createMock({
+      deploy: async () => { /* mock implementation */ }
+    });
+    
+    // Replace only the CLI service
+    const prevServices = overrideServices({ cli: mockCli });
+    
+    try {
+      // Your test code that uses services.cli
+      // services.logger is still the original implementation
+    } finally {
+      // Restore original services
+      resetServices(prevServices);
+    }
+  });
+});
+```

--- a/src/test/unit/services/cli.test.ts
+++ b/src/test/unit/services/cli.test.ts
@@ -5,12 +5,15 @@ import { createMock } from '../../../test/helpers/test-utils';
 import { StepzenCliService } from '../../../services/cli';
 import { CliError } from '../../../errors';
 import * as vscode from 'vscode';
+import { services, setMockServices, overrideServices, resetServices } from '../../../services';
+import { Logger } from '../../../services/logger';
 
 // This is a simplified test file that would be expanded in a real implementation
 // Unit tests would mock child_process.spawn and assert the service behavior
 
 suite('StepzenCliService', () => {
   let service: StepzenCliService;
+  let originalServices: any;
 
   setup(() => {
     // In a real test, we would:
@@ -18,6 +21,25 @@ suite('StepzenCliService', () => {
     // 2. Mock the fs operations
     // 3. Mock resolveStepZenProjectRoot
     service = new StepzenCliService();
+    
+    // Create a mock logger to prevent actual logging during tests
+    const mockLogger = createMock<Logger>({
+      info: () => {},
+      debug: () => {},
+      warn: () => {},
+      error: () => {},
+      getOutputChannel: () => createMock<vscode.LogOutputChannel>(),
+      updateConfigFromSettings: () => {},
+      dispose: () => {}
+    });
+    
+    // Keep original services for restoration
+    originalServices = overrideServices({ logger: mockLogger });
+  });
+  
+  teardown(() => {
+    // Restore original services after each test
+    resetServices(originalServices);
   });
 
   suite('deploy', () => {

--- a/src/test/unit/services/service-registry.test.ts
+++ b/src/test/unit/services/service-registry.test.ts
@@ -1,0 +1,110 @@
+import * as assert from 'assert';
+import { services, setMockServices, overrideServices, resetServices, ServiceRegistry } from '../../../services';
+import { createMock } from '../../helpers/test-utils';
+import { StepzenCliService } from '../../../services/cli';
+import { Logger } from '../../../services/logger';
+
+suite('Service Registry', () => {
+  let originalServices: ServiceRegistry;
+
+  // Store original services before running tests
+  suiteSetup(() => {
+    originalServices = { ...services };
+  });
+
+  // Restore original services after all tests
+  suiteTeardown(() => {
+    setMockServices(originalServices);
+  });
+
+  // Reset to original services after each test
+  teardown(() => {
+    setMockServices(originalServices);
+  });
+
+  test('services should contain cli and logger by default', () => {
+    assert.ok(services.cli instanceof StepzenCliService, 'CLI service should be an instance of StepzenCliService');
+    assert.ok(services.logger instanceof Logger, 'Logger should be an instance of Logger');
+  });
+
+  test('overrideServices should replace individual services', () => {
+    // Create a mock CLI service
+    const mockCli = createMock<StepzenCliService>({
+      deploy: async () => { /* mock implementation */ },
+      request: async () => 'mock response'
+    });
+
+    // Store the original CLI service
+    const originalCli = services.cli;
+
+    // Override only the CLI service
+    const previousServices = overrideServices({ cli: mockCli });
+
+    // Verify that the CLI service was replaced
+    assert.strictEqual(services.cli, mockCli, 'CLI service should be replaced with mock');
+    
+    // Verify that the logger service was not replaced
+    assert.strictEqual(services.logger, originalServices.logger, 'Logger service should not be modified');
+    
+    // Verify that previousServices contains the original CLI service
+    assert.strictEqual(previousServices.cli, originalCli, 'previousServices should contain the original CLI service');
+    
+    // Reset the service back to original
+    resetServices(previousServices);
+    
+    // Verify that the CLI service was restored
+    assert.strictEqual(services.cli, originalCli, 'CLI service should be restored to original');
+  });
+
+  test('setMockServices should replace all services', () => {
+    // Create complete mock services
+    const mockServices: ServiceRegistry = {
+      cli: createMock<StepzenCliService>({
+        deploy: async () => { /* mock implementation */ },
+        request: async () => 'mock response from complete mock'
+      }),
+      logger: createMock<Logger>({
+        info: () => { /* mock implementation */ },
+        error: () => { /* mock implementation */ },
+        debug: () => { /* mock implementation */ },
+        warn: () => { /* mock implementation */ }
+      })
+    };
+
+    // Replace all services with mocks
+    const previous = setMockServices(mockServices);
+
+    // Verify that all services were replaced
+    assert.strictEqual(services.cli, mockServices.cli, 'CLI service should be replaced with mock');
+    assert.strictEqual(services.logger, mockServices.logger, 'Logger service should be replaced with mock');
+    
+    // Verify that previous contains all original services
+    assert.strictEqual(previous.cli, originalServices.cli, 'previous should contain original CLI service');
+    assert.strictEqual(previous.logger, originalServices.logger, 'previous should contain original logger service');
+    
+    // Reset to original services
+    setMockServices(previous);
+    
+    // Verify services were restored
+    assert.strictEqual(services.cli, originalServices.cli, 'CLI service should be restored');
+    assert.strictEqual(services.logger, originalServices.logger, 'Logger service should be restored');
+  });
+
+  test('mocked service should be usable in place of real service', async () => {
+    // Create a mock CLI service with a specific behavior we can verify
+    const mockCli = createMock<StepzenCliService>({
+      request: async (query: string) => {
+        return `Mocked response for query: ${query}`;
+      }
+    });
+
+    // Override the CLI service
+    overrideServices({ cli: mockCli });
+
+    // Use the service through the registry
+    const result = await services.cli.request('{ test }');
+    
+    // Verify the mock works as expected
+    assert.strictEqual(result, 'Mocked response for query: { test }', 'Mock should return the expected response');
+  });
+});

--- a/src/utils/runtimeDiagnostics.ts
+++ b/src/utils/runtimeDiagnostics.ts
@@ -7,7 +7,7 @@
  * ---------------------------------------------------------*/
 import * as vscode from "vscode";
 import { findDefinition } from "../utils/stepzenProjectScanner";
-import { logger } from "../services/logger";
+import { services } from "../services";
 import { StepZenDiagnostic } from "../types";
 
 /*────────────────────────────── types ─────────────────────────────*/
@@ -64,9 +64,9 @@ export function summariseDiagnostics(raw: StepZenDiagnostic[]): Record<string, R
         }
       }
     }
-    logger.debug(`[*] Collected ${spanById.size} spans, of which ${fetchSpans.length} are fetch spans`);
+    services.logger.debug(`[*] Collected ${spanById.size} spans, of which ${fetchSpans.length} are fetch spans`);
   } else {
-    logger.debug(`[*] No OTel entry found in diagnostics`);
+    services.logger.debug(`[*] No OTel entry found in diagnostics`);
   }
 
   // ancestor-check helper
@@ -234,5 +234,5 @@ export function publishDiagnostics(
   for (const [file, diags] of perFile) {
     collection.set(vscode.Uri.parse(file), diags);
   }
-  logger.info(`StepZen runtime diagnostics → ${perFile.size} file(s)`);
+  services.logger.info(`StepZen runtime diagnostics → ${perFile.size} file(s)`);
 }

--- a/src/utils/safeRegisterCommand.ts
+++ b/src/utils/safeRegisterCommand.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { logger } from "../services/logger";
+import { services } from "../services";
 
 /**
  * Safely registers a VSCode command, capturing and reporting any errors
@@ -25,7 +25,7 @@ export function safeRegisterCommand(
   try {
     return vscode.commands.registerCommand(commandId, callback);
   } catch (err) {
-    logger.error(`Failed to register command: ${commandId}`, err);
+    services.logger.error(`Failed to register command: ${commandId}`, err);
     vscode.window.showErrorMessage(
       `StepZen Tools: Failed to register command "${commandId}"`
     );

--- a/src/utils/stepzenProject.ts
+++ b/src/utils/stepzenProject.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
-import { logger } from "../services/logger";
+import { services } from "../services";
 import { createError, formatError } from "./errors";
 
 /**
@@ -21,7 +21,7 @@ export async function resolveStepZenProjectRoot(
   if (start) {
     // Validate that the URI has a valid filesystem path
     if (!start.fsPath || typeof start.fsPath !== "string") {
-      logger.warn("Invalid path in active editor URI");
+      services.logger.warn("Invalid path in active editor URI");
     } else {
       const byAscend = ascendForConfig(path.dirname(start.fsPath));
       if (byAscend) {
@@ -31,7 +31,7 @@ export async function resolveStepZenProjectRoot(
   }
 
   // ② otherwise scan the entire workspace ---------------------------------
-  logger.info(
+  services.logger.info(
     `StepZen project not found in current folder. Scanning...`,
   );
   const configs = await vscode.workspace.findFiles(
@@ -59,7 +59,7 @@ export async function resolveStepZenProjectRoot(
   }
 
   // ③ prompt when several projects exist ----------------------------------
-  logger.info(
+  services.logger.info(
     `Multiple StepZen projects found. Prompting for selection...`,
   );
 
@@ -103,7 +103,7 @@ export async function resolveStepZenProjectRoot(
   function ascendForConfig(dir: string): string | null {
     // Validate input
     if (!dir || typeof dir !== "string") {
-      logger.error(
+      services.logger.error(
         "Invalid directory path provided to ascendForConfig"
       );
       return null;
@@ -128,7 +128,7 @@ export async function resolveStepZenProjectRoot(
         err,
         "filesystem",
       );
-      logger.error(formatError(error, true), error);
+      services.logger.error(formatError(error, true), error);
       return null;
     }
 


### PR DESCRIPTION
- Create ServiceRegistry interface for centralized service management
- Refactor service instantiation to use registry instead of direct imports
- Eliminate potential circular dependencies between services
- Add type-safe mechanisms for service mocking in tests
- Support complete service mocking and partial service overrides
- Move service mocking documentation to src/test/README.md
- Improve testability across the entire extension

This implementation addresses ARCH4 by creating a lightweight dependency
injection container that makes service dependencies explicit and testable.
Services like CLI and logger are now centrally managed instead of being
directly instantiated across multiple files.
