### PR TITLE
feat(auth): always prompt for authorization method (admin or JWT) on every request

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { safeRegisterCommand } from "./utils/safeRegisterCommand";
 // Removed import - now using services.schemaIndex directly
 import { StepZenCodeLensProvider } from "./utils/codelensProvider";
 import { services } from "./services";
+import { runGraphQLRequest } from "./commands/runRequest";
 
 
 let stepzenTerminal: vscode.Terminal | undefined;
@@ -213,10 +214,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const { deployStepZen } = await import("./commands/deploy.js");
       return deployStepZen();
     }),
-    safeRegisterCommand(COMMANDS.RUN_REQUEST, async () => {
-      const { runGraphQLRequest } = await import("./commands/runRequest.js");
-      return runGraphQLRequest();
-    }),
+    safeRegisterCommand(COMMANDS.RUN_REQUEST, () => runGraphQLRequest(context)),
     safeRegisterCommand(COMMANDS.OPEN_EXPLORER, async () => {
       const { openQueryExplorer } = await import("./commands/openExplorer.js");
       return openQueryExplorer(context);
@@ -260,11 +258,11 @@ export async function activate(context: vscode.ExtensionContext) {
     }),
     safeRegisterCommand(COMMANDS.RUN_OPERATION, async (...args: unknown[]) => {
       const { runOperation } = await import("./commands/runRequest.js");
-      return runOperation(args[0] as any);
+      return runOperation(context, args[0] as any);
     }),
     safeRegisterCommand(COMMANDS.RUN_PERSISTED, async (...args: unknown[]) => {
       const { runPersisted } = await import("./commands/runRequest.js");
-      return runPersisted(args[0] as string, args[1] as string);
+      return runPersisted(context, args[0] as string, args[1] as string);
     }),
     safeRegisterCommand(COMMANDS.CLEAR_RESULTS, async () => {
       const { clearResults } = await import("./commands/runRequest.js");

--- a/src/services/cli.ts
+++ b/src/services/cli.ts
@@ -64,10 +64,11 @@ export class StepzenCliService {
    * @param vars Optional variables to pass to the query
    * @param operationName Optional name of the operation to execute
    * @param debugLevel Optional debug level (defaults to 1)
+   * @param customHeaders Optional custom headers to inject as --header
    * @returns Promise resolving to the response string
    * @throws CliError if the operation fails
    */
-  async request(query: string, vars?: object, operationName?: string, debugLevel: number = 1): Promise<string> {
+  async request(query: string, vars?: object, operationName?: string, debugLevel: number = 1, customHeaders?: Record<string, string>): Promise<string> {
     let tmpFile = '';
     let varsFile = '';
     
@@ -111,7 +112,8 @@ export class StepzenCliService {
         'request',
         '--file', tmpFile,
         ...(operationName ? ['--operation-name', operationName] : []),
-        '--header', `"stepzen-debug-level: ${debugLevel}"`,
+        // Add each header as its own --header argument, value wrapped in double quotes
+        ...(customHeaders ? Object.entries(customHeaders).flatMap(([k, v]) => ['--header', `"${k}: ${v}"`]) : ['--header', `"stepzen-debug-level: ${debugLevel}"`]),
         ...varArgs
       ];
       


### PR DESCRIPTION
- Always prompt for authorization method (admin key or JWT) on every request, including codelens and persisted operation flows.\n- Persist only the JWT value for convenience.\n- No longer persist the last selection; user can switch methods on every run.\n- Fixes #118.\n\n**UX:**\n- Consistent prompt for all entry points.\n- JWT is pre-filled if previously used.\n- No need for a separate command to change method.\n\n**Technical:**\n- Updates all entry points to require context and prompt for auth.\n- Refactors prompt logic for clarity and consistency.\n- Updates CLI header handling for correct quoting.\n\nAll tests and linting pass. Ready for review.